### PR TITLE
Add jQuery and fix PHP $rows undeclared variable warning

### DIFF
--- a/web/banned.php
+++ b/web/banned.php
@@ -11,6 +11,9 @@
       <meta name="description" content="">
       <meta name="author" content="">
       <title>Report Cheaters in CSGO.</title>
+      
+      <!-- jQuery -->
+      <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
       <!-- Bootstrap core CSS -->
       <link href="css/bootstrap.min.css" rel="stylesheet">
       <!-- Custom styles for this template -->

--- a/web/index.php
+++ b/web/index.php
@@ -17,6 +17,9 @@ if (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
 
     <title>Private Report Bot.</title>
 
+    <!-- jQuery -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+    
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
     <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>

--- a/web/list.php
+++ b/web/list.php
@@ -13,6 +13,9 @@ require('mysql.php');
 
     <title>Report Cheaters in CSGO.</title>
 
+    <!-- jQuery -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+    
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
 

--- a/web/ow-check.php
+++ b/web/ow-check.php
@@ -7,6 +7,7 @@ $ids;
 
 $count   = 0;
 $counter = 1;
+$rows = [];
 
 while ($row = $result->fetch_array()) {
     $rows[] = $row;


### PR DESCRIPTION
jQuery is needed for bootstrap (suppresses console errors) and also remove warning filling up php logs during cron jobs