### PR TITLE
XSS and broken Server var

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -141,7 +141,7 @@ if (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
 			?>
 			<h1 class="display-3">Report:</h1>
 			<p class="lead">
-			  <form action = "<?php $_PHP_SELF ?>" method = "POST">
+          <form action = "<?php $_SERVER['PHP_SELF'] ?>" method = "POST">
 				SteamID 64: 
 				<input type = "text" placeholder="SteamID 64" name = "steamid" /><br><br>
 				MatchID (Not needed):

--- a/web/index.php
+++ b/web/index.php
@@ -141,7 +141,7 @@ if (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
 			?>
 			<h1 class="display-3">Report:</h1>
 			<p class="lead">
-          <form action = "<?php $_SERVER['PHP_SELF'] ?>" method = "POST">
+          <form action = "<?php $_SERVER['SCRIPT_NAME'] ?>" method = "POST">
 				SteamID 64: 
 				<input type = "text" placeholder="SteamID 64" name = "steamid" /><br><br>
 				MatchID (Not needed):


### PR DESCRIPTION
Stumbled upon this line by accident. It seemed broken in the first place, like a c+p error,
but even if implemenetd right PHP_SELF is unsafe.

Use SCRIPT_NAME

https://www.dzhang.com/blog/2013/05/20/php_self-and-cross-site-scripting